### PR TITLE
Update the trace file for the Towers test

### DIFF
--- a/tests/test_trace_reader/test_trace_reader.cpp
+++ b/tests/test_trace_reader/test_trace_reader.cpp
@@ -47,9 +47,9 @@ namespace m3
             {
                 currentHookData.rob_id = std::stoul(value);
             }
-            else if (key == "load_dest_reg")
+            else if (key == "rv_instruction")
             {
-                currentHookData.load_dest_reg = std::stoul(value);
+                currentHookData.rv_instruction = std::stoul(value);
             }
             else if (key == "memop_size")
             {

--- a/tests/test_trace_reader/usage_example.cpp
+++ b/tests/test_trace_reader/usage_example.cpp
@@ -11,7 +11,7 @@ void printRawHookData(const m3::RtlHookData& data, const std::string& label)
               << " (Enum: RtlHook)" << std::endl;
     std::cout << "  hart_id         : " << data.hart_id << std::endl;
     std::cout << "  rob_id          : " << data.rob_id << std::endl;
-    std::cout << "  load_dest_reg   : " << data.load_dest_reg << std::endl;
+    std::cout << "  rv_instruction  : " << data.rv_instruction << std::endl;
     std::cout << "  memop_size      : " << data.memop_size << std::endl;
     std::cout << "  address         : " << data.address << std::endl;
     std::cout << "  memop_id        : " << data.memop_id << std::endl;


### PR DESCRIPTION
This PR updates the Towers test trace file located in `./tests/traces`. Duplicate `kCompleteStore` events have been removed by starting their logging at timestamp 4894.