### PR TITLE
Re-write all tables in a single format

### DIFF
--- a/documentation/boom_integration.md
+++ b/documentation/boom_integration.md
@@ -98,7 +98,7 @@ As usual, the `hart_id` and `rob_id` are used to retrieve the corresponding m3 I
 > If the comparison fails, we do not halt the simulation immediately, unlike traditional single-core co-simulation scenarios. In this case, the load value is being checked while still in the pipeline, and it may belong to a mispredicted path. Therefore, we simply mark this memop in the Bridge's state object as having failed the comparison. The simulation is only halted if and when this load instruction commits, confirming that the incorrect value would have affected architecturally visible state.
 
 ### `st_locally_perform(Inst_id iid)` API
-This function is used when both the store's address **AND** data are available in the RTL. It depends on two RTL hooks: `AddAddress` and `AddStoreData`. The Bridge waits until both conditions are satisfied before calling `st_locally_perform()`. Invoking this API indicates that the store is now locally visible — meaning that subsequent loads issued by the same core can see data from this store, even if it hasn't committed yet. 
+This function is used when both the store's address **AND** data are available in the RTL. It depends on two RTL hooks: `AddAddress` and `AddStoreData`. The Bridge waits until both conditions are satisfied before calling `st_locally_perform()`. Invoking this API indicates that the store is now locally visible — meaning that subsequent loads issued by the same core can see data from this store, even if it hasn't committed yet.
 
 This behavior is consistent with how BOOM implements its store-to-load forwarding mechanism: as long as the store queue contains a valid address and data for a pending store, subsequent loads can read from it. Therefore, reaching these two conditions (address and data availability) is sufficient to mark the store as locally performed and ready for potential forwarding.
 
@@ -109,7 +109,7 @@ tile_reset_domain_boom_tile.lsu.stq_X_bits_addr_valid
 ```
 
 The following additional information needs to be passed from RTL:
-```
+
 | Hierarchy                                                              | Port Size |
 |------------------------------------------------------------------------|-----------|
 | tile_reset_domain_boom_tile.core.io_hartid                             | 1         |
@@ -117,7 +117,6 @@ The following additional information needs to be passed from RTL:
 | tile_reset_domain_boom_tile.lsu.stq_X_bits_uop_mem_size                | 2         |
 | tile_reset_domain_boom_tile.lsu.stq_X_bits_uop_rob_idx                 | 5         |
 | tile_reset_domain_boom_tile.lsu.(X)                                    | 3         |
-```
 
 The `X` in the signal name represents the index of an entry in the Store Queue (STQ). In a small BOOM configuration, there are 8 STQ entries. The address-related signals are triggered when any of the corresponding `addr_valid` bits go high. The underlying logic is that when an entry's address becomes available in the RTL, we want to capture this moment in the m3 tracking system. At this point, we also provide additional metadata—such as the `hartid` and `rob_id`—which allows us to retrieve the corresponding m3 ID. Using this ID, we then update the memory operation in m3 with the address and memory operation size.
 
@@ -128,13 +127,12 @@ tile_reset_domain_boom_tile.lsu.stq_X_bits_data_valid
 ```
 
 The following additional information needs to be passed from RTL:
-```
+
 | Hierarchy                                                              | Port Size |
 |------------------------------------------------------------------------|-----------|
 | tile_reset_domain_boom_tile.core.io_hartid                             | 1         |
 | tile_reset_domain_boom_tile.lsu.stq_X_bits_data_bits                   | 64        |
 | tile_reset_domain_boom_tile.lsu.stq_X_bits_uop_rob_idx                 | 5         |
-```
 
 As usual, the `hart_id` and `rob_id` are used to retrieve the corresponding m3 ID. After getting this ID, the store data is added to the memory operation in m3. When both the store's address **AND** data are available, we can invoke `st_locally_perform(Inst_id iid)`
 
@@ -151,7 +149,7 @@ tile_reset_domain_boom_tile.dcache.metaWriteArb.io_out_valid
 ```
 
 The following additional information needs to be passed from the RTL:
-```
+
 | Hierarchy                                                                                  | Port Size |
 |---------------------------------------------------------------------------------------------|-----------|
 | tile_reset_domain_boom_tile.core.io_hartid                                                  | 1         |
@@ -159,7 +157,7 @@ The following additional information needs to be passed from the RTL:
 | tile_reset_domain_boom_tile.dcache.metaWriteArb.io_out_bits_idx                             | 6         |
 | tile_reset_domain_boom_tile.dcache.metaWriteArb.io_out_bits_data_coh_state                  | 2         |
 | tile_reset_domain_boom_tile.dcache.metaWriteArb.io_out_bits_data_tag                        | 20        |
-```
+
 Once the store leaves the core, the primary metadata used to retrieve the corresponding M3 ID is the store’s address. The signals listed above are used to reconstruct this address in order to perform the lookup.
 
 #### 2) `UpdateCacheLineData` RTL Hook
@@ -171,13 +169,13 @@ tile_reset_domain_boom_tile.dcache.dataWriteArb.io_out_valid
 
 The following additional information needs to be passed from the RTL:
 
-```
+
 | Hierarchy                                                                                  | Port Size |
 |---------------------------------------------------------------------------------------------|-----------|
 | tile_reset_domain_boom_tile.core.io_hartid                                                  | 1         |
 | tile_reset_domain_boom_tile.dcache.dataWriteArb.io_out_bits_way_en                          | 4         |
 | tile_reset_domain_boom_tile.dcache.dataWriteArb.io_out_bits_addr                            | 12        |
-```
+
 Once the store leaves the core, the primary metadata used to retrieve the corresponding M3 ID is the store’s address. The signals listed above are used to reconstruct this address in order to perform the lookup.
 
 #### 3) `CommitMemop` RTL Hook
@@ -188,12 +186,11 @@ tile_reset_domain_boom_tile.core.rob.(io_commit_valids_0&(io_commit_uops_0_uses_
 ```
 
 The following additional information needs to be passed from the RTL:
-```
+
 | Hierarchy                                                              | Port Size |
 |------------------------------------------------------------------------|-----------|
 | tile_reset_domain_boom_tile.core.io_hartid                             | 1         |
 | tile_reset_domain_boom_tile.core.rob.com_idx                           | 5         |
-```
 
 These signals are used to retrieve the M3 ID. For store operations, the M3 ID is transferred from the ROB ID to the address once the store leaves the core.
 


### PR DESCRIPTION
This PR changes the tables in `documentation/boom_integration.md` from a multi-line code format to a regular table markdown format.